### PR TITLE
Handle SIGINT and SIGTERM

### DIFF
--- a/interfaces.go
+++ b/interfaces.go
@@ -7,6 +7,7 @@ import (
 	"database/sql"
 	"fmt"
 	"io/ioutil"
+	"os"
 )
 
 type Driver interface {
@@ -47,6 +48,10 @@ type FileReader interface {
 	ReadFile(filename string) ([]byte, error)
 }
 
+type Exiter interface {
+	Exit(int)
+}
+
 // dbWrapper implements the DB interface.
 type dbWrapper struct {
 	*sql.DB
@@ -64,9 +69,23 @@ func (ioutilFileReader) ReadFile(filename string) ([]byte, error) {
 	return ioutil.ReadFile(filename)
 }
 
-// fmtPrinter implements the Printer interface.
-type fmtPrinter struct{}
+// stdoutPrinter implements the Printer interface.
+type stdoutPrinter struct{}
 
-func (fmtPrinter) Print(s string) {
+func (stdoutPrinter) Print(s string) {
 	fmt.Print(s)
+}
+
+// stderrPrinter implements the Printer interface.
+type stderrPrinter struct{}
+
+func (stderrPrinter) Print(s string) {
+	fmt.Fprint(os.Stderr, s)
+}
+
+// osExiter implements the Exiter interface.
+type osExiter struct{}
+
+func (osExiter) Exit(code int) {
+	os.Exit(code)
 }

--- a/mock_interfaces_test.go
+++ b/mock_interfaces_test.go
@@ -379,3 +379,36 @@ func (m *MockFileReader) ReadFile(filename string) ([]byte, error) {
 func (mr *MockFileReaderMockRecorder) ReadFile(filename interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadFile", reflect.TypeOf((*MockFileReader)(nil).ReadFile), filename)
 }
+
+// MockExiter is a mock of Exiter interface
+type MockExiter struct {
+	ctrl     *gomock.Controller
+	recorder *MockExiterMockRecorder
+}
+
+// MockExiterMockRecorder is the mock recorder for MockExiter
+type MockExiterMockRecorder struct {
+	mock *MockExiter
+}
+
+// NewMockExiter creates a new mock instance
+func NewMockExiter(ctrl *gomock.Controller) *MockExiter {
+	mock := &MockExiter{ctrl: ctrl}
+	mock.recorder = &MockExiterMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockExiter) EXPECT() *MockExiterMockRecorder {
+	return m.recorder
+}
+
+// Exit mocks base method
+func (m *MockExiter) Exit(arg0 int) {
+	m.ctrl.Call(m, "Exit", arg0)
+}
+
+// Exit indicates an expected call of Exit
+func (mr *MockExiterMockRecorder) Exit(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Exit", reflect.TypeOf((*MockExiter)(nil).Exit), arg0)
+}


### PR DESCRIPTION
Gracefully handling `SIGINT` and `SIGTERM` but only during the execution of migration steps in a `goto` command.

I intentionally left the signals unhandled in other parts of the code because the only scenario in which handling them is useful is when executing a migration (possible consisting of multiple statements + updating the migration table) outside of a transaction (e.g.: with mysql that doesn't support DDL transactions).

Every other place uses readonly operations or single statements so I thought allowing signals to immediately stop the program could provide a better user experience.